### PR TITLE
Only expose supported algs

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -50,7 +50,7 @@ type Algorithm struct {
 }
 
 // Algorithms is an array/slice of IANA algorithms
-var Algorithms = []Algorithm{
+var algorithms = []Algorithm{
 	Algorithm{
 		Name:  "RSAES-OAEP w/ SHA-512", // RSAES-OAEP w/ SHA-512 from [RFC8230]
 		Value: -42,

--- a/common_headers.go
+++ b/common_headers.go
@@ -186,7 +186,7 @@ func GetCommonHeaderLabel(tag int) (label string, err error) {
 
 // getAlgByName returns a Algorithm for an IANA name
 func getAlgByName(name string) (alg *Algorithm, err error) {
-	for _, alg := range Algorithms {
+	for _, alg := range algorithms {
 		if alg.Name == name {
 			return &alg, nil
 		}
@@ -205,7 +205,7 @@ func getAlgByNameOrPanic(name string) (alg *Algorithm) {
 
 // getAlgByValue returns a Algorithm for an IANA value
 func getAlgByValue(value int64) (alg *Algorithm, err error) {
-	for _, alg := range Algorithms {
+	for _, alg := range algorithms {
 		if int64(alg.Value) == value {
 			return &alg, nil
 		}

--- a/common_headers.go
+++ b/common_headers.go
@@ -184,8 +184,8 @@ func GetCommonHeaderLabel(tag int) (label string, err error) {
 	}
 }
 
-// GetAlgByName returns a Algorithm for an IANA name
-func GetAlgByName(name string) (alg *Algorithm, err error) {
+// getAlgByName returns a Algorithm for an IANA name
+func getAlgByName(name string) (alg *Algorithm, err error) {
 	for _, alg := range Algorithms {
 		if alg.Name == name {
 			return &alg, nil
@@ -194,17 +194,17 @@ func GetAlgByName(name string) (alg *Algorithm, err error) {
 	return nil, fmt.Errorf("Algorithm named %s not found", name)
 }
 
-// GetAlgByNameOrPanic returns a Algorithm for an IANA name and panics otherwise
-func GetAlgByNameOrPanic(name string) (alg *Algorithm) {
-	alg, err := GetAlgByName(name)
+// getAlgByNameOrPanic returns a Algorithm for an IANA name and panics otherwise
+func getAlgByNameOrPanic(name string) (alg *Algorithm) {
+	alg, err := getAlgByName(name)
 	if err != nil {
 		panic(fmt.Sprintf("Unable to get algorithm named %s", name))
 	}
 	return alg
 }
 
-// GetAlgByValue returns a Algorithm for an IANA value
-func GetAlgByValue(value int64) (alg *Algorithm, err error) {
+// getAlgByValue returns a Algorithm for an IANA value
+func getAlgByValue(value int64) (alg *Algorithm, err error) {
 	for _, alg := range Algorithms {
 		if int64(alg.Value) == value {
 			return &alg, nil
@@ -227,7 +227,7 @@ func CompressHeaders(headers map[interface{}]interface{}) (compressed map[interf
 				k = tag
 
 				if kstr == "alg" && vok {
-					alg, err := GetAlgByName(vstr)
+					alg, err := getAlgByName(vstr)
 					if err == nil {
 						v = alg.Value
 					}
@@ -253,7 +253,7 @@ func DecompressHeaders(headers map[interface{}]interface{}) (decompressed map[in
 			if err == nil {
 				k = label
 				if label == "alg" && vok {
-					alg, err := GetAlgByValue(int64(vint))
+					alg, err := getAlgByValue(int64(vint))
 					if err == nil {
 						v = alg.Name
 					}
@@ -270,7 +270,7 @@ func DecompressHeaders(headers map[interface{}]interface{}) (decompressed map[in
 func getAlg(h *Headers) (alg *Algorithm, err error) {
 	if tmp, ok := h.Protected["alg"]; ok {
 		if algName, ok := tmp.(string); ok {
-			alg, err = GetAlgByName(algName)
+			alg, err = getAlgByName(algName)
 			if err != nil {
 				return nil, err
 			}
@@ -278,7 +278,7 @@ func getAlg(h *Headers) (alg *Algorithm, err error) {
 		}
 	} else if tmp, ok := h.Protected[uint64(1)]; ok {
 		if algValue, ok := tmp.(int64); ok {
-			alg, err = GetAlgByValue(algValue)
+			alg, err = getAlgByValue(algValue)
 			if err != nil {
 				return nil, err
 			}
@@ -286,7 +286,7 @@ func getAlg(h *Headers) (alg *Algorithm, err error) {
 		}
 	} else if tmp, ok := h.Protected[int(1)]; ok {
 		if algValue, ok := tmp.(int); ok {
-			alg, err = GetAlgByValue(int64(algValue))
+			alg, err = getAlgByValue(int64(algValue))
 			if err != nil {
 				return nil, err
 			}

--- a/core.go
+++ b/core.go
@@ -29,10 +29,10 @@ const (
 
 var (
 	// Supported Algorithms
-	PS256 = GetAlgByNameOrPanic("PS256")
-	ES256 = GetAlgByNameOrPanic("ES256")
-	ES384 = GetAlgByNameOrPanic("ES384")
-	ES512 = GetAlgByNameOrPanic("ES512")
+	PS256 = getAlgByNameOrPanic("PS256")
+	ES256 = getAlgByNameOrPanic("ES256")
+	ES384 = getAlgByNameOrPanic("ES384")
+	ES512 = getAlgByNameOrPanic("ES512")
 )
 
 // Signer holds a COSE Algorithm and private key for signing messages

--- a/core_test.go
+++ b/core_test.go
@@ -83,14 +83,13 @@ func TestSignerPublic(t *testing.T) {
 	assert.Panics(func () { ecdsaSigner.Public() })
 }
 
-
 func TestVerifyInvalidAlgErrors(t *testing.T) {
 	assert := assert.New(t)
 
 	signer, err := NewSignerFromKey(ES256, &ecdsaPrivateKey)
 	assert.Nil(err, "Error creating signer")
 
-	verifier := signer.Verifier(GetAlgByNameOrPanic("A128GCM"))
+	verifier := signer.Verifier(getAlgByNameOrPanic("A128GCM"))
 	assert.Nil(err, "Error creating verifier")
 
 	err = verifier.Verify([]byte(""), []byte(""))

--- a/example/verify.go
+++ b/example/verify.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// derive a verifier from out signer's public key
-	verifier := signer.Verifier(cose.GetAlgByNameOrPanic("ES256"))
+	verifier := signer.Verifier(cose.ES256)
 
 	// Verify
 	err = msg.Verify(external, []cose.Verifier{*verifier})

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -623,7 +623,7 @@ var XPI_PAYLOAD = [...]byte{
 //
 // processed with:
 // s/const/var/g
-// SignatureAlgorithm::\([A-Z0-9]+\) → GetAlgByNameOrPanic("\1")
+// SignatureAlgorithm::\([A-Z0-9]+\) → getAlgByNameOrPanic("\1")
 // s/&test:://g
 // s/: COSERustSignatureParameters//g
 // s/_EE/_EE[:]/g
@@ -636,22 +636,22 @@ type COSERustSignatureParameters struct {
 
 var P256_PARAMS = COSERustSignatureParameters{
 	certificate: P256_EE[:],
-	algorithm:   GetAlgByNameOrPanic("ES256"),
+	algorithm:   ES256,
 	pkcs8:       PKCS8_P256_EE[:],
 }
 var P384_PARAMS = COSERustSignatureParameters{
 	certificate: P384_EE[:],
-	algorithm:   GetAlgByNameOrPanic("ES384"),
+	algorithm:   ES384,
 	pkcs8:       PKCS8_P384_EE[:],
 }
 var P521_PARAMS = COSERustSignatureParameters{
 	certificate: P521_EE[:],
-	algorithm:   GetAlgByNameOrPanic("ES512"),
+	algorithm:   ES512,
 	pkcs8:       PKCS8_P521_EE[:],
 }
 var RSA_PARAMS = COSERustSignatureParameters{
 	certificate: RSA_EE[:],
-	algorithm:   GetAlgByNameOrPanic("PS256"),
+	algorithm:   PS256,
 	pkcs8:       PKCS8_RSA_EE[:],
 }
 
@@ -675,7 +675,7 @@ var RustTestCases = []RustTestCase{
 	// {
 	// 	Title: "test_nss_sign_verify",
 	// 	SignPayload: []byte("sample"),
-	// 	SignAlg: GetAlgByNameOrPanic("ES256"),
+	// 	SignAlg: getAlgByNameOrPanic("ES256"),
 	// 	// nss::sign(&SignatureAlgorithm::ES256, PKCS8_P256_EE, payload)
 	// 	// nss::verify_signature(
 	// 	// 	&SignatureAlgorithm::ES256,
@@ -688,7 +688,7 @@ var RustTestCases = []RustTestCase{
 	// 	// Verify the signature with a different payload.
 	// 	Title: "test_nss_sign_verify_different_payload",
 	// 	SignPayload: []byte("sample"),
-	// 	SignAlg: GetAlgByNameOrPanic("ES256"),
+	// 	SignAlg: getAlgByNameOrPanic("ES256"),
 	// 	VerifyPayload: []byte("sampli"),
 	//
 	// 	// nss::sign(&SignatureAlgorithm::ES256, PKCS8_P256_EE, payload);
@@ -705,7 +705,7 @@ var RustTestCases = []RustTestCase{
 	// 	// Verify the signature with a wrong cert.
 	// 	Title: "test_nss_sign_verify_wrong_cert",
 	// 	SignPayload: []byte("sample"),
-	// 	SignAlg: GetAlgByNameOrPanic("ES256"),
+	// 	SignAlg: getAlgByNameOrPanic("ES256"),
 
 	// 	// verify_result = nss::verify_signature(
 	// 	// 	&SignatureAlgorithm::ES256,
@@ -777,7 +777,7 @@ var RustTestCases = []RustTestCase{
 	// 	Params: []COSERustSignatureParameters{
 	// 		COSERustSignatureParameters{
 	// 			certificate: P384_EE[:],
-	// 			algorithm: GetAlgByNameOrPanic("ES256"),
+	// 			algorithm: ES256,
 	// 			pkcs8: PKCS8_P256_EE[:],
 	// 		},
 	// 	},

--- a/sign_verify_cose_wg_examples_test.go
+++ b/sign_verify_cose_wg_examples_test.go
@@ -17,7 +17,7 @@ func WGExampleSignsAndVerifies(t *testing.T, example WGExample) {
 	assert.Equal(len(example.Input.Sign.Signers), 1)
 
 	signerInput := example.Input.Sign.Signers[0]
-	alg := GetAlgByNameOrPanic(signerInput.Protected.Alg)
+	alg := getAlgByNameOrPanic(signerInput.Protected.Alg)
 	external := HexToBytesOrDie(signerInput.External)
 
 	decoded, err := Unmarshal(HexToBytesOrDie(example.Output.Cbor))


### PR DESCRIPTION
These interfaces are still in flux, so we'd rather only let people use the global vars to supported Algs.