### PR TITLE
sign_verify: return pointer to SignMessage from NewSignMessage

### DIFF
--- a/cbor_test.go
+++ b/cbor_test.go
@@ -262,7 +262,7 @@ func TestCBORDecodeNilSignMessagePayload(t *testing.T) {
 
 	result, err := Unmarshal(b)
 	assert.Nil(err)
-	assert.Equal(result, msg)
+	assert.Equal(result, *msg)
 
 	bytes, err := Marshal(result)
 	assert.Nil(err)

--- a/sign_verify.go
+++ b/sign_verify.go
@@ -80,10 +80,10 @@ type SignMessage struct {
 	Signatures []Signature
 }
 
-// NewSignMessage takes a []byte payload and returns a new SignMessage
-// with empty headers and signatures
-func NewSignMessage() (msg SignMessage) {
-	msg = SignMessage{
+// NewSignMessage takes a []byte payload and returns a new pointer to
+// a SignMessage with empty headers and signatures
+func NewSignMessage() *SignMessage {
+	return &SignMessage{
 		Headers: &Headers{
 			Protected:   map[interface{}]interface{}{},
 			Unprotected: map[interface{}]interface{}{},
@@ -91,7 +91,6 @@ func NewSignMessage() (msg SignMessage) {
 		Payload:    nil,
 		Signatures: nil,
 	}
-	return msg
 }
 
 // AddSignature adds a signature to the message signatures creating an

--- a/sign_verify_test.go
+++ b/sign_verify_test.go
@@ -184,8 +184,7 @@ func TestSignMessageSignatureDigest(t *testing.T) {
 	assert.Equal(err.Error(), "SignMessage.Signatures does not include the signature to digest")
 	assert.Equal(len(digest), 0)
 
-	tmp := NewSignMessage()
-	msg = &tmp
+	msg = NewSignMessage()
 	signature = NewSignature()
 	signature.Headers.Protected[algTag] = ES256
 	msg.Signatures = []Signature{*signature}


### PR DESCRIPTION
refs: https://github.com/mozilla-services/autograph/pull/76#discussion_r197904833

Fixes bug from learning golang

r? @jvehent 