### PR TITLE
make Verifier fields public

### DIFF
--- a/core.go
+++ b/core.go
@@ -185,26 +185,26 @@ func (s *Signer) Sign(rand io.Reader, digest []byte) (signature []byte, err erro
 // Algorithm
 func (s *Signer) Verifier() (verifier *Verifier) {
 	return &Verifier{
-		publicKey: s.Public(),
-		alg:       s.alg,
+		PublicKey: s.Public(),
+		Alg:       s.alg,
 	}
 }
 
 // Verifier holds a PublicKey and Algorithm to verify signatures
 type Verifier struct {
-	publicKey crypto.PublicKey
-	alg       *Algorithm
+	PublicKey crypto.PublicKey
+	Alg       *Algorithm
 }
 
 // Verify verifies a signature returning nil for success or an error
 func (v *Verifier) Verify(digest []byte, signature []byte) (err error) {
-	if v.alg.Value > -1 { // Negative numbers are used for second layer objects (COSE_Signature and COSE_recipient)
+	if v.Alg.Value > -1 { // Negative numbers are used for second layer objects (COSE_Signature and COSE_recipient)
 		return ErrInvalidAlg
 	}
 
-	switch key := v.publicKey.(type) {
+	switch key := v.PublicKey.(type) {
 	case *rsa.PublicKey:
-		hashFunc := v.alg.HashFunc
+		hashFunc := v.Alg.HashFunc
 
 		err = rsa.VerifyPSS(key, hashFunc, digest, signature, &rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthEqualsHash,
@@ -215,18 +215,18 @@ func (v *Verifier) Verify(digest []byte, signature []byte) (err error) {
 		}
 		return nil
 	case *ecdsa.PublicKey:
-		if v.alg.privateKeyECDSACurve == nil {
+		if v.Alg.privateKeyECDSACurve == nil {
 			return fmt.Errorf("Could not find an elliptic curve for the ecdsa algorithm")
 		}
 
-		algCurveBitSize := v.alg.privateKeyECDSACurve.Params().BitSize
+		algCurveBitSize := v.Alg.privateKeyECDSACurve.Params().BitSize
 		keyCurveBitSize := key.Curve.Params().BitSize
 
 		if algCurveBitSize != keyCurveBitSize {
 			return fmt.Errorf("Expected %d bit key, got %d bits instead", algCurveBitSize, keyCurveBitSize)
 		}
 
-		algKeyBytesSize := ecdsaCurveKeyBytesSize(v.alg.privateKeyECDSACurve)
+		algKeyBytesSize := ecdsaCurveKeyBytesSize(v.Alg.privateKeyECDSACurve)
 
 		// signature bytes is the keys with padding r and s
 		if len(signature) != 2*algKeyBytesSize {

--- a/core_test.go
+++ b/core_test.go
@@ -174,32 +174,32 @@ func TestVerifyInvalidAlgErrors(t *testing.T) {
 
 	verifier := signer.Verifier()
 
-	verifier.alg.Value = 20
+	verifier.Alg.Value = 20
 	err = verifier.Verify([]byte(""), []byte(""))
 	assert.Equal(ErrInvalidAlg, err)
 
-	verifier.alg.Value = -7
+	verifier.Alg.Value = -7
 
-	verifier.publicKey = rsaPrivateKey.Public()
-	verifier.alg = PS256
+	verifier.PublicKey = rsaPrivateKey.Public()
+	verifier.Alg = PS256
 	err = verifier.Verify([]byte(""), []byte(""))
 	assert.NotNil(err)
 	assert.Equal("verification failed rsa.VerifyPSS err crypto/rsa: verification error", err.Error())
 
-	verifier.publicKey = dsaPrivateKey.PublicKey
-	verifier.alg = ES256
+	verifier.PublicKey = dsaPrivateKey.PublicKey
+	verifier.Alg = ES256
 	err = verifier.Verify([]byte(""), []byte(""))
 	assert.NotNil(err)
 	assert.Equal("Unrecognized public key type", err.Error())
 
-	verifier.publicKey = ecdsaPrivateKey.Public()
-	verifier.alg = ES256
-	verifier.alg.privateKeyECDSACurve = nil
+	verifier.PublicKey = ecdsaPrivateKey.Public()
+	verifier.Alg = ES256
+	verifier.Alg.privateKeyECDSACurve = nil
 	err = verifier.Verify([]byte(""), []byte(""))
 	assert.NotNil(err)
 	assert.Equal("Could not find an elliptic curve for the ecdsa algorithm", err.Error())
 
-	verifier.alg.privateKeyECDSACurve = elliptic.P256()
+	verifier.Alg.privateKeyECDSACurve = elliptic.P256()
 }
 
 func TestFromBase64IntErrors(t *testing.T) {

--- a/sign_verify_test.go
+++ b/sign_verify_test.go
@@ -244,20 +244,20 @@ func TestVerifyErrors(t *testing.T) {
 
 	verifiers = []Verifier{
 		Verifier{
-			publicKey: &ecdsa.PublicKey{
+			PublicKey: &ecdsa.PublicKey{
 				Curve: elliptic.P384(),
 				X:     FromBase64Int("usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8"),
 				Y:     FromBase64Int("IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4"),
 			},
-			alg: ES256,
+			Alg: ES256,
 		},
 	}
 	assert.Equal(errors.New("Expected 256 bit key, got 384 bits instead"), msg.Verify(payload, verifiers))
 
 	verifiers = []Verifier{
 		Verifier{
-			publicKey: ecdsaPrivateKey.Public(),
-			alg: ES256,
+			PublicKey: ecdsaPrivateKey.Public(),
+			Alg: ES256,
 		},
 	}
 	assert.Equal(errors.New("invalid signature length: 14"), msg.Verify(payload, verifiers))


### PR DESCRIPTION
mirrors:
https://github.com/mozilla-services/autograph/pull/76/commits/02037275624d7c14f724db1305433c5387f71654
with test fixes

i.e. publicKey to PublicKey and alg to Alg

r? @ajvb 