### PR TITLE
make: fix ci failure due to extra -repotoken arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ smoketest-examples:
 	go run example/verify.go
 
 ci: install-godep install-golint goveralls install coverage lint vet
-	goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $(COVERALLS_TOKEN)
+	goveralls -coverprofile=coverage.out -service=travis-ci


### PR DESCRIPTION
per the docs:

> For a public github repository, it is not necessary to define your
  repository key (COVERALLS_TOKEN).

https://github.com/mattn/goveralls#travis-ci