### PR TITLE
Replace ugorji/go with fxamacker/cbor to improve security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.2.1-0.20200429214022-fc263b46c618
 	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.1
-	github.com/ugorji/go v0.0.0-20180112141927-9831f2c3ac10
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,12 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20200429214022-fc263b46c618 h1:RIQZGQ00xy1acO7H7mjL8N5ZDyI0soZG7X8akiXwSTo=
+github.com/fxamacker/cbor/v2 v2.2.1-0.20200429214022-fc263b46c618/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.1 h1:52QO5WkIUcHGIR7EnGagH88x1bUzqGXTC5/1bDTUQ7U=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/ugorji/go v0.0.0-20180112141927-9831f2c3ac10 h1:4zp+5ElNBLy5qmaDFrbVDolQSOtPmquw+W6EMNEpi+k=
-github.com/ugorji/go v0.0.0-20180112141927-9831f2c3ac10/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=


### PR DESCRIPTION
Replaced ugorji/go with fxamacker/cbor without changing go-cose API.

Also this PR improves performance and memory usage for encoding and decoding SignMessage.

Using ugorji/go library:
```
BenchmarkDecodeCOSE-2   	  6362 ns/op	    3843 B/op	      62 allocs/op
BenchmarkEncodeCOSE-2   	  4717 ns/op	    4816 B/op	      57 allocs/op
```

Using fxamacker/cbor/v2 library:
```
BenchmarkDecodeCOSE-2   	  4319 ns/op	    2328 B/op	      39 allocs/op
BenchmarkEncodeCOSE-2   	  3480 ns/op	    2275 B/op	      26 allocs/op
```

Benchmarks use [RFC 8152 Appendix C.1.1 data](https://tools.ietf.org/html/rfc8152#appendix-C.1.1).

Closes #62 