### PR TITLE
Fix tests for tampered sig and modified payload

### DIFF
--- a/sign_verify_cose_rust_cli_test.go
+++ b/sign_verify_cose_rust_cli_test.go
@@ -5,10 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // signing tests for Firefox Addon COSE Signatures
@@ -58,10 +59,10 @@ func RustCoseVerifiesGoCoseSignatures(t *testing.T, testCase RustTestCase) {
 	if testCase.ModifySignature {
 		// tamper with the COSE signature.
 		sig1 := message.Signatures[0].SignatureBytes
-		sig1[len(sig1)-5] ^= sig1[len(sig1)-5]
+		sig1[len(sig1)-5] ^= 1
 	}
 	if testCase.ModifyPayload {
-		message.Payload[0] ^= message.Payload[0]
+		message.Payload[0] ^= 1
 	}
 
 	message.Payload = nil


### PR DESCRIPTION
Two tests used to modify a single byte of signature or payload by XORing it with itself, causing the target byte to be zero.

* test_cose_sign_verify_tampered_signature
* test_cose_sign_verify_modified_payload

If the original data in the target byte was already zero, then nothing was changed, causing the test to fail.

Fix this by changing bitwise operation to XOR the target byte with a 1, so the target byte will always change by 1 bit.

Closes #68