### PR TITLE
WIP: Adding Ed25519 support

### DIFF
--- a/algorithms.go
+++ b/algorithms.go
@@ -20,6 +20,9 @@ const (
 
 	// KeyTypeECDSA is the type to generate an ecdsa.PrivateKey
 	KeyTypeECDSA KeyType = iota
+
+	// KeyTypeEdDSA is the type to generate an eddsa.PrivateKey
+	KeyTypeEdDSA KeyType = iota
 )
 
 // Algorithm represents an IANA algorithm's parameters (Name,
@@ -42,7 +45,7 @@ type Algorithm struct {
 	Value              int
 
 	// optional fields
-	HashFunc           crypto.Hash    // hash function for SignMessages
+	HashFunc           *crypto.Hash    // hash function for SignMessages
 	privateKeyType     KeyType        // private key type to generate for new Signers
 
 	minRSAKeyBitLen    int            // minimimum RSA key size to generate in bits
@@ -75,21 +78,21 @@ var algorithms = []Algorithm{
 	Algorithm{
 		Name:            "PS256", // RSASSA-PSS w/ SHA-256 from [RFC8230]
 		Value:           -37,
-		HashFunc:        crypto.SHA256,
+		HashFunc:        func(h crypto.Hash) *crypto.Hash { return &h }(crypto.SHA256),
 		privateKeyType:  KeyTypeRSA,
 		minRSAKeyBitLen: 2048,
 	},
 	Algorithm{
 		Name:               "ES512", // ECDSA w/ SHA-512 from [RFC8152]
 		Value:              -36,
-		HashFunc:           crypto.SHA512,
+		HashFunc:           func(h crypto.Hash) *crypto.Hash { return &h }(crypto.SHA512),
 		privateKeyType:     KeyTypeECDSA,
 		privateKeyECDSACurve:    elliptic.P521(),
 	},
 	Algorithm{
 		Name:               "ES384", // ECDSA w/ SHA-384 from [RFC8152]
 		Value:              -35,
-		HashFunc:           crypto.SHA384,
+		HashFunc:           func(h crypto.Hash) *crypto.Hash { return &h }(crypto.SHA384),
 		privateKeyType:     KeyTypeECDSA,
 		privateKeyECDSACurve:    elliptic.P384(),
 	},
@@ -151,12 +154,13 @@ var algorithms = []Algorithm{
 	},
 	Algorithm{
 		Name:  "EdDSA", // EdDSA from [RFC8152]
+        privateKeyType: KeyTypeEdDSA,
 		Value: -8,
 	},
 	Algorithm{
 		Name:               "ES256", // ECDSA w/ SHA-256 from [RFC8152]
 		Value:              -7,
-		HashFunc:           crypto.SHA256,
+		HashFunc:           func(h crypto.Hash) *crypto.Hash { return &h }(crypto.SHA256),
 		privateKeyType:     KeyTypeECDSA,
 		privateKeyECDSACurve:    elliptic.P256(),
 	},

--- a/core_test.go
+++ b/core_test.go
@@ -66,14 +66,14 @@ func TestNewSigner(t *testing.T) {
 	_, err = NewSigner(PS256, nil)
 	assert.Nil(err)
 
-	edDSA := getAlgByNameOrPanic("EdDSA")
+	ps512 := getAlgByNameOrPanic("PS512")
 
-	signer, err := NewSigner(edDSA, nil)
+	signer, err := NewSigner(ps512, nil)
 	assert.NotNil(err)
 	assert.Equal(err.Error(), ErrUnknownPrivateKeyType.Error())
 
-	edDSA.privateKeyType = KeyTypeECDSA
-	signer, err = NewSigner(edDSA, nil)
+	ps512.privateKeyType = KeyTypeECDSA
+	signer, err = NewSigner(ps512, nil)
 	assert.NotNil(err)
 	assert.Equal(err.Error(), "No ECDSA curve found for algorithm")
 

--- a/sign_verify.go
+++ b/sign_verify.go
@@ -120,7 +120,7 @@ func (m *SignMessage) SigStructure(external []byte, signature *Signature) (ToBeS
 // signatureDigest takes an extra external byte slice and a Signature
 // and returns the SigStructure (i.e. ToBeSigned) hashed using the
 // algorithm from the signature parameter
-func (m *SignMessage) signatureDigest(external []byte, signature *Signature, hashFunc crypto.Hash) (digest []byte, err error) {
+func (m *SignMessage) signatureDigest(external []byte, signature *Signature, hashFunc *crypto.Hash) (digest []byte, err error) {
 	if m == nil {
 		err = errors.Errorf("Cannot compute signatureDigest on nil SignMessage")
 		return

--- a/sign_verify_cose_wg_examples_test.go
+++ b/sign_verify_cose_wg_examples_test.go
@@ -11,7 +11,6 @@ import (
 
 func WGExampleSignsAndVerifies(t *testing.T, example WGExample) {
 	assert := assert.New(t)
-	privateKey := LoadPrivateKey(&example)
 
 	// testcases only include one signature
 	assert.Equal(len(example.Input.Sign.Signers), 1)
@@ -30,8 +29,17 @@ func WGExampleSignsAndVerifies(t *testing.T, example WGExample) {
 	message, ok := decoded.(SignMessage)
 	assert.True(ok, fmt.Sprintf("%s: Error casting example CBOR to SignMessage", example.Title))
 
-	signer, err := NewSignerFromKey(alg, privateKey)
-	assert.Nil(err, fmt.Sprintf("%s: Error creating signer %s", example.Title, err))
+    var signer *Signer
+    switch signerInput.Key.Kty {
+        case "EC":
+            privateKey := LoadECPrivateKey(&example)
+            signer, err = NewSignerFromKey(alg, &privateKey)
+            assert.Nil(err, fmt.Sprintf("%s: Error creating signer %s", example.Title, err))
+        case "OKP":
+            privateKey := LoadOKPPrivateKey(&example)
+            signer, err = NewSignerFromKey(alg, &privateKey)
+            assert.Nil(err, fmt.Sprintf("%s: Error creating signer %s", example.Title, err))
+    }
 
 	verifier := signer.Verifier()
 

--- a/sign_verify_cose_wg_examples_test.go
+++ b/sign_verify_cose_wg_examples_test.go
@@ -30,7 +30,7 @@ func WGExampleSignsAndVerifies(t *testing.T, example WGExample) {
 	message, ok := decoded.(SignMessage)
 	assert.True(ok, fmt.Sprintf("%s: Error casting example CBOR to SignMessage", example.Title))
 
-	signer, err := NewSignerFromKey(alg, &privateKey)
+	signer, err := NewSignerFromKey(alg, privateKey)
 	assert.Nil(err, fmt.Sprintf("%s: Error creating signer %s", example.Title, err))
 
 	verifier := signer.Verifier()
@@ -86,6 +86,9 @@ var SkipExampleTitles = map[string]bool{
 	"ECDSA-sig-02: ECDSA - P-384 - sign1":               true, // ecdsa-sig-02.json
 	"ECDSA-03: ECDSA - P-512 - sign0":                   true, // ecdsa-sig-03.json
 	"ECDSA-sig-01: ECDSA - P-256 w/ SHA-512 - implicit": true, // ecdsa-sig-04.json
+	"EdDSA-02: EdDSA - 448":                             true, // eddsa-01.json
+	"EdDSA-01: EdDSA - 25519 - sign0":                   true, // eddsa-sig-01.json
+	"EdDSA-sig-02: EdDSA - 448 - sign1":                 true, // eddsa-sig-01.json
 }
 
 func ExpectCastToFail(title string) (shouldFail bool) {
@@ -96,10 +99,15 @@ func ExpectCastToFail(title string) (shouldFail bool) {
 }
 
 func TestWGExamples(t *testing.T) {
-	examples := append(
-		LoadExamples("./test/cose-wg-examples/sign-tests"),
-		LoadExamples("./test/cose-wg-examples/ecdsa-examples")...,
-	)
+	var examples []WGExample
+
+	for _, dir := range []string{
+		"sign-tests",
+		"eddsa-examples",
+		"ecdsa-examples",
+	} {
+		examples = append(examples, LoadExamples("./test/cose-wg-examples/"+dir)...)
+	}
 
 	for _, example := range examples {
 		t.Run(fmt.Sprintf("Example: %s %v", example.Title, example.Fail), func(t *testing.T) {

--- a/sign_verify_test.go
+++ b/sign_verify_test.go
@@ -162,12 +162,12 @@ func TestSignMessageSignatureDigest(t *testing.T) {
 		err error
 	)
 
-	digest, err = msg.signatureDigest(external, signature, hashFunc)
+	digest, err = msg.signatureDigest(external, signature, &hashFunc)
 	assert.Equal(err.Error(), "Cannot compute signatureDigest on nil SignMessage")
 	assert.Equal(len(digest), 0)
 
 	msg = &SignMessage{}
-	digest, err = msg.signatureDigest(external, signature, hashFunc)
+	digest, err = msg.signatureDigest(external, signature, &hashFunc)
 	assert.Equal(err.Error(), "Cannot compute signatureDigest on nil SignMessage.Signatures")
 	assert.Equal(len(digest), 0)
 
@@ -179,7 +179,7 @@ func TestSignMessageSignatureDigest(t *testing.T) {
 		Headers: nil,
 		SignatureBytes: nil,
 	}
-	digest, err = msg.signatureDigest(external, signature, hashFunc)
+	digest, err = msg.signatureDigest(external, signature, &hashFunc)
 	assert.Equal(err.Error(), "SignMessage.Signatures does not include the signature to digest")
 	assert.Equal(len(digest), 0)
 
@@ -187,7 +187,7 @@ func TestSignMessageSignatureDigest(t *testing.T) {
 	signature = NewSignature()
 	signature.Headers.Protected[algTag] = ES256
 	msg.Signatures = []Signature{*signature}
-	digest, err = msg.signatureDigest(nil, signature, hashFunc)
+	digest, err = msg.signatureDigest(nil, signature, &hashFunc)
 	assert.Equal(err, nil, "signatureDigest does not accept nil external")
 }
 


### PR DESCRIPTION
Hey @g-k thanks for the great work here!

In this PR I’m adding Ed25519 support.

`go test -v -run TestWGExamples` passes but other tests are still failing. I thought I’d get your feedback on some things before going any further: Ed25119 doesn’t require messages be hashed before signing. I’ve converted the HashFunc to a pointer on `Algorithm`.  Now we can skip hashing if `algorithm.HashFunc == nil`. Is there some way we can avoid using pointers there or somewhere else to put the check? Let me know what you think.

If it’s easy to make some changes that pass the tests go for it! Or if you’ve got feedback I’d be happy to take another stab when I have a minute.

Thanks!

-Mason

