### PR TITLE
ci: drop go 1.13 support; add 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,5 @@
 version: 2
 jobs:
-  "golang-1.13":
-    docker:
-      - image: circleci/golang:1.13
-    working_directory: /go/src/go.mozilla.org/cose/
-    environment:
-      - GO111MODULE: "on" # yaml sees an unquoted on value as "true" but go checks for "on"
-    steps:
-      - checkout
-      - run:
-          name: install rust and cargo
-          command: |
-            sudo apt-get install libnss3-dev
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-            source $HOME/.cargo/env
-            echo $PATH
-            which cargo
-      - run:
-          name: print rust and cargo version information
-          command: |
-            source $HOME/.cargo/env
-            rustc --version
-            cargo --version
-      - run:
-          name: run tests
-          command: |
-            source $HOME/.cargo/env
-            make ci
   "golang-1.14":
     docker:
       - image: circleci/golang:1.14
@@ -54,9 +27,36 @@ jobs:
           command: |
             source $HOME/.cargo/env
             make ci
+  "golang-1.15":
+    docker:
+      - image: circleci/golang:1.15
+    working_directory: /go/src/go.mozilla.org/cose/
+    environment:
+      - GO111MODULE: "on" # yaml sees an unquoted on value as "true" but go checks for "on"
+    steps:
+      - checkout
+      - run:
+          name: install rust and cargo
+          command: |
+            sudo apt-get install libnss3-dev
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+            source $HOME/.cargo/env
+            echo $PATH
+            which cargo
+      - run:
+          name: print rust and cargo version information
+          command: |
+            source $HOME/.cargo/env
+            rustc --version
+            cargo --version
+      - run:
+          name: run tests
+          command: |
+            source $HOME/.cargo/env
+            make ci
   "lint":
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     working_directory: /go/src/go.mozilla.org/cose/
     environment:
       - GO111MODULE: "on" # yaml sees an unquoted on value as "true" but go checks for "on"
@@ -84,5 +84,5 @@ workflows:
   build:
     jobs:
       - "lint"
-      - "golang-1.13"
       - "golang-1.14"
+      - "golang-1.15"


### PR DESCRIPTION
The PR drops support for Go 1.13 and adds support for Go 1.15 in CircleCI config.
Closes #71 